### PR TITLE
add W503 .flake

### DIFF
--- a/.flake8
+++ b/.flake8
@@ -1,4 +1,4 @@
 [flake8]
-ignore = E501
+ignore = E501, W503
 max-line-length = 88
 extend-ignore = E203


### PR DESCRIPTION
Add W503 because it seems there was a conflict between the code formatter and .flake8 because of this (unuseful) error